### PR TITLE
Fix buffer overflow when building partition table

### DIFF
--- a/restore/restore.c
+++ b/restore/restore.c
@@ -1536,7 +1536,7 @@ build_partition_table (struct backup_info *info, int devno)
 				tmppartno--;
 
 			if (partitions[tmppartno] < 255)
-				memmove (&partitions[tmppartno + 1], &partitions[tmppartno], 16 - tmppartno);
+				memmove (&partitions[tmppartno + 1], &partitions[tmppartno], 15 - tmppartno);
 			partitions[tmppartno] = partno;
 			const char *pname = partition_strings[devno][partno][0];
 			const char *ptype = partition_strings[devno][partno][1];


### PR DESCRIPTION
Fixed small bug in restore.c when the partition table is being manipulated.  Since the table has at most 16 entries, when copying from n+1 to n, the distance from n+1 to the end of the table is 16-(n+1)=15-n, not 16-n.  Building the repo on Ubuntu 24 triggers the buffer overflow error due to a memory checker being included by default.